### PR TITLE
fix index.html template error and added media url to home.urls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,15 @@
 {
     "python.pythonPath": "${workspaceFolder}/env/bin/python3",
     "editor.formatOnSave": true,
-    "python.linting.pep8Enabled": true,
+    "python.linting.pycodestyleEnabled": true,
     "python.linting.pylintPath": "pylint",
     "python.linting.pylintArgs": ["--load-plugins", "pylint_django"],
     "python.linting.pylintEnabled": true,
     "python.venvPath": "${workspaceFolder}/env/bin/python3",
-    "python.linting.pep8Args": ["--ignore=E501"],
+    "python.linting.pycodestyleArgs": ["--ignore=E501"],
     "files.exclude": {
       "**/*.pyc": true
-    }
+    },
+    "eslint.enable": false,
+    "jshint.enable": false
   }

--- a/home/settings/base.py
+++ b/home/settings/base.py
@@ -63,7 +63,7 @@ STATIC_URL = '/static/'
 MEDIA_URL = '/media/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'build/static')]
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media').replace('\\', '/')
 SITE_ID = 1
 
 REST_FRAMEWORK = {

--- a/home/urls.py
+++ b/home/urls.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 from django.urls import path, include, re_path
 from django.views.generic import TemplateView
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('api-auth/', include('rest_framework.urls')),
     path('rest-auth/', include('rest_auth.urls')),
     path('rest-auth/registration/', include('rest_auth.registration.urls')),
     path('admin/', admin.site.urls),
-    re_path(r'^.*', TemplateView.as_view(template_name='index.html')),
-]
+    # re_path(r'^.*', TemplateView.as_view(template_name='index.html')),
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Hello, I Observed that the wildcard URL at home.URLs were causing issues as it was matching every path and the index.html template it is pointing to does not exist, this leads to an error were any attempt to open any URL results in a template not found error, so I commented it out and that fixed it. Also, the media files were not being found because the path was not added to the Home.URLs file, I fixed that and now it's working properly. Great work on the boilerplate man!! it really saved me a lot of time.